### PR TITLE
Adding the monkey patch for insertAdjacentELement

### DIFF
--- a/setupJest.js
+++ b/setupJest.js
@@ -1,1 +1,37 @@
+import iface from 'jsdom/lib/jsdom/living/generated/Element'
+
+Element.prototype.insertAdjacentElement = function insertAdjacentElement(position, node) {
+    position = position.toLowerCase();
+    
+    switch (position) {
+        case "beforebegin": {
+            if (this.parentNode === null || this.parentNode.nodeType === NODE_TYPE.DOCUMENT_NODE) {
+                throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR, "Cannot insert HTML adjacent to " +"parent-less nodes or children of document nodes.");
+            } else {
+                this.parentNode.insertBefore(node, this);
+            }
+            break;
+        }
+        case "afterend": {
+            if (this.parentNode === null || this.parentNode.nodeType === NODE_TYPE.DOCUMENT_NODE) {
+                throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR, "Cannot insert HTML adjacent to " +"parent-less nodes or children of document nodes.");
+            } else {
+                this.parentNode.insertBefore(node, this.nextSibling);
+            }
+            break;
+        }
+        case "afterbegin": {
+            this.insertBefore(node, this.firstChild);
+            break;
+        }
+        case "beforeend": {
+            this.appendChild(node);
+            break;
+        }
+        default: {
+            throw new DOMException(DOMException.SYNTAX_ERR, "Must provide one of \"beforebegin\", \"afterend\", " +"\"afterbegin\", or \"beforeend\".");
+        }
+    }
+}
+
 global.fetch = require('jest-fetch-mock')

--- a/src/fix-links.test.js
+++ b/src/fix-links.test.js
@@ -9,15 +9,9 @@ describe('fixLinks', () => {
     test('should insert the <base> element into <head>', async () => {
         const doc = window.document.implementation.createHTMLDocument()
         const rootElement = doc.documentElement
-        doc.querySelector('head').insertAdjacentElement = jest.fn()
-        const docUrl = 'about:blank'
+        const docUrl = 'https://example.com/page/'
         await fixLinks({rootElement, docUrl})
-        const base = document.createElement('base')
-        base.href = docUrl
-        // XXX insertAdjacentElement is not yet implemented in jsdom. This test is a placeholder
-        // until a better solution arises.
-        expect(rootElement.querySelector('head').insertAdjacentElement)
-            .toBeCalledWith('afterbegin', base)
+        expect(rootElement.querySelector('base').href).toBe(docUrl)
     })
 
     test('should do nothing for absolute URLs', async () => {

--- a/src/set-content-security-policy.test.js
+++ b/src/set-content-security-policy.test.js
@@ -11,11 +11,10 @@ describe('setContentSecurityPolicy', () => {
             "style-src data: 'unsafe-inline'",
             "font-src data:",
         ]
+        const csp = policyDirectives.join('; ')
         const doc = window.document.implementation.createHTMLDocument()
-        // XXX insertAdjacentElement is not yet implemented in jsdom. This test is a placeholder
-        // until a better solution arises.
-        doc.querySelector('head').insertAdjacentElement = jest.fn()
         setContentSecurityPolicy({doc, policyDirectives})
-        expect(doc.querySelector('head').insertAdjacentElement).toHaveBeenCalled()
+        expect(doc.querySelector('meta').getAttribute('http-equiv')).toBe('Content-Security-Policy')
+        expect(doc.querySelector('meta').content).toBe(csp)
     })
 })


### PR DESCRIPTION
Finally we have a better solution for ```insertAdjacentElement```. We monkey patch the function to the jest setup, this allows us to implement our own implementation of the function on top of the existing code of jsdom.