### PR TITLE
Use postcss CSS parser, crawl @imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,7 +1580,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -1588,8 +1587,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1884,8 +1882,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.1",
@@ -2066,6 +2063,11 @@
       "requires": {
         "locate-path": "^2.0.0"
       }
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3268,6 +3270,11 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4322,6 +4329,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "memoize-one": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.0.tgz",
+      "integrity": "sha512-wdpOJ4XBejprGn/xhd1i2XR8Dv1A25FJeIvR7syQhQlz9eXsv+06llcvcmBxlWVGv4C73QBsWA8kxvZozzNwiQ=="
+    },
     "memoize-weak": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/memoize-weak/-/memoize-weak-1.0.2.tgz",
@@ -4837,6 +4849,64 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postcss": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.1.tgz",
+      "integrity": "sha512-c6M68yZX0bWnZ0GcX8duWcfweGeGQvYgw6w4xksRePDmrpCrLMqneN07xwce17ACWBAr0S+DoI0T31axZ21TKg==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-values-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
+      "integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6088,6 +6158,11 @@
           }
         }
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,12 @@
     "blob-util": "^1.3.0",
     "document-outerhtml": "^0.1.0",
     "domnode-at-path": "^1.0.0",
+    "memoize-one": "^4.0.0",
     "memoize-weak": "^1.0.2",
     "mutable-proxy": "^0.1.7",
     "path-to-domnode": "^1.0.1",
+    "postcss": "^7.0.1",
+    "postcss-values-parser": "^1.5.0",
     "when-all-settled": "^0.1.1"
   },
   "jest": {

--- a/src/crawl-subresources.js
+++ b/src/crawl-subresources.js
@@ -10,7 +10,7 @@ import { extractLinksFromDom, extractLinksFromCss } from './extract-links'
  * @returns nothing; subresources are stored in the links of the given resource.
  */
 async function crawlSubresourcesOfDom(resource) {
-    const supportedSubresourceTypes = ['image', 'document', 'style', 'video']
+    const supportedSubresourceTypes = ['image', 'document', 'style', 'video', 'font']
 
     // TODO Avoid fetching all resolutions&formats of the same image/video?
     const linksToCrawl = resource.links
@@ -28,6 +28,7 @@ async function crawlSubresource(link) {
         document: crawlFrame,
         style: crawlStylesheet,
         video: crawlLeafSubresource, // Videos cannot have subresources (afaik; maybe they can?)
+        font: crawlLeafSubresource, // Fonts cannot have subresources (afaik; maybe they can?)
     }
     const crawler = crawlers[link.subresourceType]
     if (crawler === undefined) {

--- a/src/extract-links/Readme.md
+++ b/src/extract-links/Readme.md
@@ -27,14 +27,42 @@ Usage example: (assume the document just contains `<a href="/page"><img src="img
 
 ### For a stylesheet
 
-    extractLinksFromCss({ set, get, baseUrl })
+To manipulate the links inside a stylesheet, we want a representation of the stylesheet that permits
+mutation. Multiple approaches are supported:
 
-Stylesheets are taken in their string form (using [CSSOM] is a future possibility). However, because Javascript strings are immutable but we do want to have the same features as with links in the DOM, you do not pass the stylesheet as a string. Rather, you pass a getter and setter, that will access or replace the stylesheet string. Also, you should pass a `baseUrl` for interpreting any relative links the stylesheet may contain.
+1. Passing the AST (Abstract Syntax Tree) produced by [postcss][] as the object we work on.
+2. Passing a getter and a setter of the stylesheet string.
+3. *(possibly in the future: a [CSSOM][] CSSStylesheet or CSSStyleDeclaration)*
+
+In either case, you should pass a `baseUrl` for interpreting any relative links the stylesheet may
+contain.
+
+#### Using [postcss]
+
+    extractLinksFromCss(parsedCss, baseUrl)
+
+Where `parsedCss` is a postcss Root node.
+
+Example usage:
+
+    const parsedCss = postcss.parse(`body { background: url('bg.png'); }`)
+    const links = extractLinksFromCss(parsedCss, baseUrl)
+
+    links[0].target = 'other.png'
+    // parsedCss.toResult().css === `body { background: url('other.png'); }`
+
+#### Syncing with a string
+
+    extractLinksFromCssSynced({ get, set, baseUrl })
+
+Note this is form interally runs `extractLinksFromCss`. And in its turn, this form is used by
+`extractLinksFromDom` in order to extract links found within a `<style>` tag or `style` element
+attribute.
 
 Example usage:
 
     let stylesheetString = `body { background: url('bg.png'); }`
-    const links = extractLinksFromCss({
+    const links = extractLinksFromCssSynced({
         get: () => stylesheetString,
         set: newValue => { stylesheetString = newValue },
         baseUrl: stylesheetUrl,
@@ -45,11 +73,14 @@ Example usage:
 
 ## Properties of a link
 
-The properties of link are 'live' views on the link in the document, always reflecting the current value. Except for `target`, all properties are read-only.
+The properties of link are 'live' views on the link in the document, always reflecting the current
+value. Except for `target`, all properties are read-only.
 
-- `target`: the link's target URL. This is the exact value as it appears in the document, and may thus be a relative URL. This property can be written to, which will modify the document.
+- `target`: the link's target URL. This is the exact value as it appears in the document, and may
+  thus be a relative URL. This property can be written to, which will modify the document.
 
-- `absoluteTarget`: the link's target URL as an absolute URL. This takes into account factors like the <base href="..."> tag, so usually you may prefer to use `absoluteTarget` rather than `target`.
+- `absoluteTarget`: the link's target URL as an absolute URL. This takes into account factors like
+  the <base href="..."> tag, so usually you may prefer to use `absoluteTarget` rather than `target`.
 
 - `from`: information needed to find the link in the DOM or stylesheet, for scenarios where one
   needs to do more than just reading or modifying the link target.
@@ -63,7 +94,7 @@ The properties of link are 'live' views on the link in the document, always refl
   - if defined in text (only possible inside a `<style>` tag):
     `{ element, rangeWithinTextContent: [ start, end ] }`
 
-  For links in a CSS stylesheet (i.e. using `extractLinksFromCss`):
+  For links in a CSS stylesheet (i.e. using `extractLinksFromCss`(`Synced`)):
   - `{ range: [ start, end ] }`
 
   As usual, range ends are exclusive; so `start - end === link.target.length` holds.
@@ -114,4 +145,5 @@ the `srcset`. In any case, we would have to run extractLinksFromDom again to get
 
 [WHATWG fetch spec]: https://fetch.spec.whatwg.org/#concept-request-destination (as of 2018-05-17)
 [attribute lists]: url-attributes/attribute-lists.js
+[postcss]: https://postcss.org/
 [CSSOM]: https://www.w3.org/TR/cssom-1/

--- a/src/extract-links/Readme.md
+++ b/src/extract-links/Readme.md
@@ -94,8 +94,7 @@ value. Except for `target`, all properties are read-only.
   - if defined in text (only possible inside a `<style>` tag):
     `{ element, rangeWithinTextContent: [ start, end ] }`
 
-  For links in a CSS stylesheet (i.e. using `extractLinksFromCss`(`Synced`)):
-  - `{ range: [ start, end ] }`
+  **The `from` attribute is currently not giving the position of links inside CSS**
 
   As usual, range ends are exclusive; so `start - end === link.target.length` holds.
   </details>

--- a/src/extract-links/from-css.js
+++ b/src/extract-links/from-css.js
@@ -39,7 +39,7 @@ export function extractLinksFromCss({ get, set, baseUrl }) {
     return links
 }
 
-export function parseUrlsFromStylesheet(stylesheetText) {
+function parseUrlsFromStylesheet(stylesheetText) {
     // TODO replace regex-based extractor with actual CSS parser.
     const cssExtractUrlPattern = /(url\s*\(\s*('|")?\s*)([^"')]+?)\s*\2\s*\)/i
     // TODO capture @import and @font-face statements

--- a/src/extract-links/from-css.js
+++ b/src/extract-links/from-css.js
@@ -44,6 +44,7 @@ export function extractLinksFromCss(parsedCss, baseUrl) {
                 get subresourceType() { return 'style' },
                 get from() {
                     // TODO combine atRule.source.start.{line|column} with urlNode.sourceIndex
+                    // But.. those numbers are not updated when the AST is mutated. Hopeless.
                     // (if urlNode.type === 'string', offset by 1 to account for the quote)
                     return {}
                 },
@@ -88,6 +89,7 @@ export function extractLinksFromCss(parsedCss, baseUrl) {
                     get subresourceType() { return subresourceType },
                     get from() {
                         // TODO combine decl.source.start.{line|column} with urlNode.sourceIndex
+                        // But.. those numbers are not updated when the AST is mutated. Hopeless.
                         // (if urlNode.type === 'string', offset by 1 to account for the quote)
                         return {}
                     },

--- a/src/extract-links/from-css.js
+++ b/src/extract-links/from-css.js
@@ -1,68 +1,148 @@
-import { syncingParsedView } from './parse-tools.js'
+import valuesParser from 'postcss-values-parser'
+import postcss from 'postcss'
+import memoizeOne from 'memoize-one'
+
+import { deepSyncingProxy, transformingCache } from './parse-tools'
 
 /**
  * Extract links from a stylesheet.
- * @param options
- * @param {() => string} options.get - getter to obtain the current content of the stylesheet.
- * @param {string => void} options.set - setter that is called, whenever a link is modified, with
- * the new value of the whole stylesheet.
- * @param {string} options.baseUrl - the absolute URL for interpreting any relative URLs in the
- * stylesheet.
+ * @param {Object} parsedCss - An AST as produced by postcss.parse()
+ * @param {string} baseUrl - the absolute URL for interpreting any relative URLs in the stylesheet.
  * @returns {Object[]} The extracted links. Each link provides a live, editable view on one URL
  * inside the stylesheet.
  */
-export function extractLinksFromCss({ get, set, baseUrl }) {
-    const parsedStylesheetView = syncingParsedView({
-        parse: parseUrlsFromStylesheet,
-        get,
-        set,
+export function extractLinksFromCss(parsedCss, baseUrl) {
+    const links = []
+
+    // Grab all @import urls
+    parsedCss.walkAtRules('import', atRule => {
+        const valueAst = valuesParser(atRule.params).parse()
+
+        let urlNode
+        const firstNode = valueAst.nodes[0].nodes[0]
+        if (firstNode.type === 'string') {
+            urlNode = firstNode
+        }
+        else if (firstNode.type === 'func' && firstNode.value === 'url') {
+            const argument = firstNode.nodes[1] // nodes[0] is the opening parenthesis.
+            if (argument.type === 'string' || argument.type === 'word') {
+                urlNode = argument // For either type, argument.value is our URL.
+            }
+        }
+
+        if (urlNode) {
+            links.push({
+                get target() { return urlNode.value },
+                set target(newUrl) {
+                    urlNode.value = newUrl
+                    atRule.params = valueAst.toString()
+                },
+                get absoluteTarget() {
+                    return new URL(this.target, baseUrl).href
+                },
+                get isSubresource() { return true },
+                get subresourceType() { return 'style' },
+                get from() {
+                    // TODO combine atRule.source.start.{line|column} with urlNode.sourceIndex
+                    // (if urlNode.type === 'string', offset by 1 to account for the quote)
+                    return {}
+                },
+            })
+        }
     })
 
-    const links = parsedStylesheetView.map(tokenView => ({
-        get target() { return tokenView.token },
-        set target(newUrl) { tokenView.token = newUrl },
-        get absoluteTarget() {
-            const target = tokenView.token
-            return new URL(target, baseUrl).href
-        },
-        get isSubresource() { return tokenView.note.isSubresource },
-        get subresourceType() { return tokenView.note.subresourceType },
+    // Grab every url(...) inside a property value; also gets those within @font-face.
+    parsedCss.walkDecls(decl => {
+        // TODO Possible future optimisation: only parse props known to allow a URL.
+        const valueAst = valuesParser(decl.value).parse()
+        valueAst.walk(functionNode => { // walkFunctionNodes seems broken? Testing manually then.
+            if (functionNode.type !== 'func') return
+            if (functionNode.value !== 'url') return
 
-        get from() {
-            const index = tokenView.index
-            return {
-                range: [index, index + tokenView.token.length],
+            let subresourceType
+            if (
+                decl.prop === 'src'
+                && decl.parent.type === 'atrule'
+                && decl.parent.name === 'font-face'
+            ) {
+                subresourceType = 'font'
+            } else {
+                // As far as I know, all other props that can contain a url specify an image.
+                subresourceType = 'image'
             }
-        },
-    }))
+
+            const argument = functionNode.nodes[1] // nodes[0] is the opening parenthesis.
+            if (argument.type === 'string' || argument.type === 'word') {
+                const urlNode = argument // For either type, argument.value is our URL.
+
+                links.push({
+                    get target() { return urlNode.value },
+                    set target(newUrl) {
+                        urlNode.value = newUrl
+                        decl.value = valueAst.toString()
+                    },
+                    get absoluteTarget() {
+                        return new URL(this.target, baseUrl).href
+                    },
+                    get isSubresource() { return true },
+                    get subresourceType() { return subresourceType },
+                    get from() {
+                        // TODO combine decl.source.start.{line|column} with urlNode.sourceIndex
+                        // (if urlNode.type === 'string', offset by 1 to account for the quote)
+                        return {}
+                    },
+                })
+            }
+        })
+    })
 
     return links
 }
 
-function parseUrlsFromStylesheet(stylesheetText) {
-    // TODO replace regex-based extractor with actual CSS parser.
-    const cssExtractUrlPattern = /(url\s*\(\s*('|")?\s*)([^"')]+?)\s*\2\s*\)/i
-    // TODO capture @import and @font-face statements
+/**
+ * Create a live&editable view on the links in a stylesheet.
+ * @param options
+ * @param {() => string} options.get - getter to obtain the current content of the stylesheet. This
+ * may be called many times, so keep it light; e.g. just reading a variable or style attribute.
+ * @param {string => void} options.set - setter that is called, whenever a link is modified, with
+ * the new value of the whole stylesheet.
+ * @param {string} options.baseUrl - the absolute URL for interpreting any relative URLs in the
+ * stylesheet.
+ */
+export function extractLinksFromCssSynced({ get: getCssString, set: setCssString, baseUrl }) {
+    // We run two steps: string to AST to links; each getter is cached. Changes to links will
+    // update the AST automatically, but we do have to write back the AST to the string.
+    // cssString <===|===> parsedCss <------|===> links
+    //            set|get             mutate|get
 
-    const urls = []
-    let remainder = stylesheetText
-    let remainderIndex = 0
-    while (remainder.length > 0) {
-        const match = remainder.match(cssExtractUrlPattern)
-        if (!match) break
+    // Wrap get and set so we can get and set the AST directly, without reparsing when unnecessary.
+    const { get: getParsedCss, set: setParsedCss } = transformingCache({
+        get: getCssString,
+        set: setCssString,
+        transform: cssString => postcss.parse(cssString),
+        untransform: parsedCss => parsedCss.toResult().css,
+    })
 
-        const url = match[3]
-        urls.push({
-            token: url,
-            index: remainderIndex + match.index + match[1].length,
-            note: {
-                isSubresource: true, // each URL in a stylesheet defines a subresource
-                subresourceType: 'image', // or 'font' or 'style' (for @import)
-            },
-        })
-        const charactersSeen = match.index + match[0].length
-        remainder = remainder.slice(charactersSeen, )
-        remainderIndex += charactersSeen
-    }
-    return urls
+    // Memoise, such that when we get the AST from cache, we get the extracted links from cache too.
+    const memoizedExtractLinksFromCss = memoizeOne(extractLinksFromCss)
+
+    // Make a proxy so that `links` is always up-to-date and its modifications are written back.
+    // For the curious: note that wrapping {get,set}parsedCss in a deepSyncingProxy would not work:
+    // access to its members would be wrapped, but a method like walkAtRules would not wrap the
+    // arguments to its callback, so operations performed on them would not be noticed. Therefore,
+    // we manually remember currentParsedCss and set() it whenever (any member of) the links object
+    // has been operated on.
+    let currentParsedCss
+    const links = deepSyncingProxy({
+        get: () => {
+            currentParsedCss = getParsedCss()
+            return memoizedExtractLinksFromCss(currentParsedCss, baseUrl)
+        },
+        set: links => {
+            // No need to use the given argument; any of links setters will have already updated the
+            // AST (i.e. currentParsedCss), so that is the thing we have to sync now.
+            setParsedCss(currentParsedCss)
+        },
+    })
+    return links
 }

--- a/src/extract-links/from-css.js
+++ b/src/extract-links/from-css.js
@@ -135,13 +135,21 @@ export function extractLinksFromCssSynced({ get: getCssString, set: setCssString
     let currentParsedCss
     const links = deepSyncingProxy({
         get: () => {
-            currentParsedCss = getParsedCss()
-            return memoizedExtractLinksFromCss(currentParsedCss, baseUrl)
+            try {
+                currentParsedCss = getParsedCss()
+                return memoizedExtractLinksFromCss(currentParsedCss, baseUrl)
+            } catch (err) {
+                // Corrupt CSS is treated as containing no links at all.
+                currentParsedCss = null
+                return []
+            }
         },
         set: links => {
             // No need to use the given argument; any of links setters will have already updated the
             // AST (i.e. currentParsedCss), so that is the thing we have to sync now.
-            setParsedCss(currentParsedCss)
+            if (currentParsedCss !== null) {
+                setParsedCss(currentParsedCss)
+            }
         },
     })
     return links

--- a/src/extract-links/from-css.test.js
+++ b/src/extract-links/from-css.test.js
@@ -1,0 +1,201 @@
+import postcss from 'postcss'
+
+import { extractLinksFromCss, extractLinksFromCssSynced } from './from-css'
+
+const exampleCssString = `
+    @import 'sheet2.css' screen and orientation('landscape');
+    @font-face {
+        font-family: "My Font";
+        src: url("/fonts/myfont.woff2") format("woff2"),
+             url("/fonts/myfont.woff") format("woff");
+    }
+    body {
+        color: rgba(255, 128, 255, 0.5);
+        background: url('https://example.org/image.png');
+    }
+    p {
+        background-image: url('background.png');
+    }
+`
+
+const exampleCssStringWithReplacedUrls = `
+    @import 'new-target0' screen and orientation('landscape');
+    @font-face {
+        font-family: "My Font";
+        src: url("new-target1") format("woff2"),
+             url("new-target2") format("woff");
+    }
+    body {
+        color: rgba(255, 128, 255, 0.5);
+        background: url('new-target3');
+    }
+    p {
+        background-image: url('new-target4');
+    }
+`
+
+describe('extractLinksFromCss', () => {
+    test('should find all URLs in a typical example', () => {
+        const parsedCss = postcss.parse(exampleCssString)
+
+        const links = extractLinksFromCss(parsedCss, 'https://base.url/stylesheet.css')
+
+        expect(links.length).toEqual(5)
+
+        expect(links[0].subresourceType).toEqual('style')
+        expect(links[1].subresourceType).toEqual('font')
+        expect(links[2].subresourceType).toEqual('font')
+        expect(links[3].subresourceType).toEqual('image')
+        expect(links[4].subresourceType).toEqual('image')
+
+        expect(links[0].target).toEqual('sheet2.css')
+        expect(links[0].absoluteTarget).toEqual('https://base.url/sheet2.css')
+
+        expect(links[1].target).toEqual('/fonts/myfont.woff2')
+        expect(links[1].absoluteTarget).toEqual('https://base.url/fonts/myfont.woff2')
+
+        expect(links[4].target).toEqual('background.png')
+        expect(links[4].absoluteTarget).toEqual('https://base.url/background.png')
+    })
+
+    test('should correctly update URLs in a typical example', () => {
+        const parsedCss = postcss.parse(exampleCssString)
+
+        const links = extractLinksFromCss(parsedCss, 'https://base.url/stylesheet.css')
+
+        links[0].target = 'new-target0'
+        links[1].target = 'new-target1'
+        links[2].target = 'new-target2'
+        links[3].target = 'new-target3'
+        links[4].target = 'new-target4'
+
+        expect(parsedCss.toResult().css).toEqual(exampleCssStringWithReplacedUrls)
+    })
+
+    test('should work given only the contents within a rule', () => {
+        const cssString = `
+            background-image: url('background.png');
+            color: blue;
+            cursor: url('cursor.png'), pointer
+        `
+        const parsedCss = postcss.parse(cssString)
+
+        const links = extractLinksFromCss(parsedCss, 'https://base.url/')
+
+        expect(links).toHaveLength(2)
+        expect(links[0].target).toEqual('background.png')
+        expect(links[1].target).toEqual('cursor.png')
+    })
+
+    test('should find any @import link', () => {
+        const cssString = `
+            @charset "utf-8";
+            @import "other-sheet0.css";
+            @import url(other-sheet1.css);
+            @import url("other-sheet2.css");
+            @import url('other-sheet3.css');
+        `
+        const parsedCss = postcss.parse(cssString)
+
+        const links = extractLinksFromCss(parsedCss, 'https://base.url/stylesheet.css')
+
+        expect(links).toHaveLength(4)
+        expect(links[0].target).toBe('other-sheet0.css')
+        expect(links[1].target).toBe('other-sheet1.css')
+        expect(links[2].target).toBe('other-sheet2.css')
+        expect(links[3].target).toBe('other-sheet3.css')
+    })
+
+    test('should find any image link', () => {
+        const cssString = `
+            body {
+                background: no-repeat center/80% url("bg.png"),
+                            url(bg2.png) cover, rgba(0,0,0,0.5);
+                cursor: url('cursor.png'), pointer;
+            }
+        `
+        const parsedCss = postcss.parse(cssString)
+
+        const links = extractLinksFromCss(parsedCss, 'https://base.url/stylesheet.css')
+
+        expect(links).toHaveLength(3)
+        expect(links[0].target).toBe('bg.png')
+        expect(links[1].target).toBe('bg2.png')
+        expect(links[2].target).toBe('cursor.png')
+
+        expect(links[0].isSubresource).toEqual(true)
+        expect(links[0].subresourceType).toEqual('image')
+    })
+
+    test('should find any @font-face link', () => {
+        const cssString = `
+            @font-face {
+                font-family: "My Font";
+                src: url("/fonts/myfont.woff2") format("woff2"),
+                     url('/fonts/myfont.woff') format("woff"),
+                     url(/fonts/myfont.ttf) format("ttf");
+            }
+        `
+        const parsedCss = postcss.parse(cssString)
+
+        const links = extractLinksFromCss(parsedCss, 'https://base.url/stylesheet.css')
+
+        expect(links).toHaveLength(3)
+        expect(links[0].target).toBe('/fonts/myfont.woff2')
+        expect(links[1].target).toBe('/fonts/myfont.woff')
+        expect(links[2].target).toBe('/fonts/myfont.ttf')
+
+        expect(links[0].isSubresource).toEqual(true)
+        expect(links[0].subresourceType).toEqual('font')
+    })
+})
+
+describe('extractLinksFromCssSynced', () => {
+    let cssString
+    let links
+
+    beforeEach(() => {
+        cssString = `p { background-image: url('background.png'); }`
+        links = extractLinksFromCssSynced({
+            get: () => { return cssString },
+            set: v => { cssString = v },
+            baseUrl: 'https://base.url/',
+        })
+    })
+
+    test('should give the current link target', () => {
+        const firstLink = links[0]
+
+        expect(firstLink.target).toEqual('background.png')
+
+        cssString = `p { background-image: url('another.png'); }`
+
+        // Check via both the previous and current value of links[0]
+        expect(firstLink.target).toEqual('another.png')
+        expect(links[0].target).toEqual('another.png')
+    })
+
+    test('should give new additional links', () => {
+        const firstLink = links[0]
+
+        cssString = `
+            div { background-image: url('newUrl.png'); }
+            p { background-image: url('background.png'); }
+        `
+
+        expect(links).toHaveLength(2)
+        expect(links[0].target).toEqual('newUrl.png')
+        expect(links[1].target).toEqual('background.png')
+
+        // Note that firstLink always points to what is *currently* the first link. We do not do any
+        // smart diffing to follow the 'same' link from one cssString to the next.
+        expect(firstLink.target).toEqual('newUrl.png')
+    })
+
+    test('should update the CSS string', () => {
+        links[0].target = 'other.png'
+
+        expect(links[0].target).toEqual('other.png')
+        expect(cssString).toEqual(`p { background-image: url('other.png'); }`)
+    })
+})

--- a/src/extract-links/from-css.test.js
+++ b/src/extract-links/from-css.test.js
@@ -192,6 +192,22 @@ describe('extractLinksFromCssSynced', () => {
         expect(firstLink.target).toEqual('newUrl.png')
     })
 
+    test('should throw when accessing a removed link', () => {
+        cssString = `
+            div { background-image: url('newUrl.png'); }
+            p { background-image: url('background.png'); }
+        `
+
+        const secondLink = links[1]
+
+        cssString = `
+            div { background-image: url('newUrl.png'); }
+        `
+
+        expect(links).toHaveLength(1)
+        expect(() => secondLink.target).toThrow(TypeError)
+    })
+
     test('should update the CSS string', () => {
         links[0].target = 'other.png'
 

--- a/src/extract-links/from-css.test.js
+++ b/src/extract-links/from-css.test.js
@@ -214,4 +214,12 @@ describe('extractLinksFromCssSynced', () => {
         expect(links[0].target).toEqual('other.png')
         expect(cssString).toEqual(`p { background-image: url('other.png'); }`)
     })
+
+    test('should simply pretend corrupt CSS contains no links', () => {
+        cssString = `p { bla url(blub); }`
+
+        expect(links).toHaveLength(0)
+        // ..and should not accidentally change the string either.
+        expect(cssString).toEqual(`p { bla url(blub); }`)
+    })
 })

--- a/src/extract-links/from-dom.js
+++ b/src/extract-links/from-dom.js
@@ -1,6 +1,6 @@
 import getBaseUrl from './get-base-url'
 import { syncingParsedView } from './parse-tools'
-import { extractLinksFromCss } from './from-css'
+import { extractLinksFromCssSynced } from './from-css'
 import urlAttributes from './url-attributes'
 import { flatMap } from './util'
 
@@ -58,8 +58,7 @@ function linksInAttribute({ element, attributeInfo, baseUrl, docUrl }) {
         get target() { return tokenView.token },
         set target(newUrl) { tokenView.token = newUrl },
         get absoluteTarget() {
-            const target = tokenView.token
-            return makeAbsolute(target, element, baseUrl, docUrl)
+            return makeAbsolute(this.target, element, baseUrl, docUrl)
         },
 
         get from() {
@@ -86,7 +85,7 @@ function extractLinksFromStyleAttributes({ rootElement, baseUrl }) {
     const elements = Array.from(rootElement.querySelectorAll(querySelector))
     const links = flatMap(elements, element => {
         // Extract the links from the CSS using a live&editable view on the attribute value.
-        const cssLinks = extractLinksFromCss({
+        const cssLinks = extractLinksFromCssSynced({
             get: () => element.getAttribute('style'),
             set: newValue => { element.setAttribute('style', newValue) },
             baseUrl: baseUrl || element.baseURI,
@@ -117,7 +116,7 @@ function extractLinksFromStyleTags({ rootElement, baseUrl }) {
 
     const links = flatMap(elements, element => {
         // Extract the links from the CSS using a live&editable view on the content.
-        const cssLinks = extractLinksFromCss({
+        const cssLinks = extractLinksFromCssSynced({
             get: () => element.textContent,
             set: newValue => { element.textContent = newValue },
             baseUrl: baseUrl || element.baseURI,

--- a/src/extract-links/from-dom.js
+++ b/src/extract-links/from-dom.js
@@ -2,7 +2,7 @@ import getBaseUrl from './get-base-url'
 import { syncingParsedView } from './parse-tools'
 import { extractLinksFromCss } from './from-css'
 import urlAttributes from './url-attributes'
-import { assignProperties, flatMap } from './util'
+import { flatMap } from './util'
 
 /**
  * Extracts links from an HTML Document.
@@ -94,15 +94,16 @@ function extractLinksFromStyleAttributes({ rootElement, baseUrl }) {
 
         // Tweak the links to describe the 'from' info from the DOM's perspective.
         const links = cssLinks.map(link =>
-            assignProperties(link, {
-                get from() {
-                    return {
+            // Use javascript's prototype inheritance, overriding the `from` property descriptor.
+            Object.create(link, {
+                from: {
+                    get: () => ({
                         get element() { return element },
                         get attribute() { return 'style' },
                         get rangeWithinAttribute() { return link.from.range },
-                    }
+                    }),
                 },
-            }),
+            })
         )
 
         return links // links in the style attribute of *this* element
@@ -124,14 +125,15 @@ function extractLinksFromStyleTags({ rootElement, baseUrl }) {
 
         // Tweak the links to describe the 'from' info from the DOM's perspective.
         const links = cssLinks.map(link =>
-            assignProperties(link, {
-                get from() {
-                    return {
+            // Use javascript's prototype inheritance, overriding the `from` property descriptor.
+            Object.create(link, {
+                from: {
+                    get: () => ({
                         get element() { return element },
                         get rangeWithinTextContent() { return link.from.range },
-                    }
+                    }),
                 },
-            }),
+            })
         )
 
         return links // links in this style element

--- a/src/extract-links/index.js
+++ b/src/extract-links/index.js
@@ -1,2 +1,2 @@
-export { extractLinksFromCss } from './from-css'
+export { extractLinksFromCss, extractLinksFromCssSynced } from './from-css'
 export { extractLinksFromDom } from './from-dom'

--- a/src/extract-links/parse-tools.test.js
+++ b/src/extract-links/parse-tools.test.js
@@ -105,6 +105,33 @@ describe('deepSyncingProxy', () => {
         expect(innerProxy.v).toEqual(3)
         expect(currentObject.t.u.v).toEqual(3)
     })
+
+    test('should throw a TypeError when accessing a member object that has disappeared', () => {
+        currentObject = { t: { u: { v: 2 } } }
+        const proxy = deepSyncingProxy({ get: getCurrentObject, set: setCurrentObject })
+
+        const innerProxy = proxy.t.u
+
+        currentObject = { t: { u: null } }
+        expect(() => innerProxy.v).toThrow(
+            TypeError('Expected get().t.u to be an object, but get().t.u is null.')
+        )
+
+        currentObject = { t: { u: 98 } } // A primitive value cannot be proxied either.
+        expect(() => innerProxy.v).toThrow(
+            TypeError('Expected get().t.u to be an object, but get().t.u is 98.')
+        )
+
+        currentObject = {}
+        expect(() => innerProxy.v).toThrow(
+            TypeError('Expected get().t.u to be an object, but get().t is undefined.')
+        )
+
+        currentObject = null
+        expect(() => innerProxy.v).toThrow(
+            TypeError('Expected get().t.u to be an object, but get() is null.')
+        )
+    })
 })
 
 describe('transformingCache', () => {

--- a/src/extract-links/util.js
+++ b/src/extract-links/util.js
@@ -1,29 +1,4 @@
 /**
- * Like Object.assign, but copying property descriptors rather than property values. Also does not
- * mutate any of the objects.
- * @param {...Object} objects - The objects to be merged. Later objects override previous objects in
- * case of conflicting keys.
- * @returns {Object} A new object, with property descriptors copied from the given objects.
- */
-export const assignProperties = (...objects) => objects.reduce(assignProperties_inner, {})
-
-const assignProperties_inner = (object1, object2) => {
-    for (const propertyName of Object.getOwnPropertyNames(object2)) {
-        const propertyDescriptor = Object.getOwnPropertyDescriptor(object2, propertyName)
-        // Uncommenting the code below would allow assigning a setter/getter without overwriting
-        // the corresponding getter/setter (respectively). Would that behaviour be more desirable?
-        // if (propertyDescriptor.get === undefined) {
-        //     delete propertyDescriptor.get
-        // }
-        // if (propertyDescriptor.set === undefined) {
-        //     delete propertyDescriptor.set
-        // }
-        Object.defineProperty(object1, propertyName, propertyDescriptor)
-    }
-    return object1
-}
-
-/**
  * Combined map and flatten.
  */
 export const flatMap = (arr, f) => arr.map(f).reduce((newArr, item) => newArr.concat(item), [])

--- a/src/extract-links/util.test.js
+++ b/src/extract-links/util.test.js
@@ -1,45 +1,4 @@
-import { assignProperties, flatMap } from './util'
-
-describe('assignProperties', () => {
-    test('should assign from left to right', () => {
-        const result = assignProperties({ n: 1 }, { n: 2, k: 5 }, { n: 3 })
-        expect(result).toEqual({ n: 3, k: 5 })
-    })
-
-    test('should keep getters alive', () => {
-        let x
-        const a = {
-            get x() { return x },
-        }
-        const b = {
-            get x2() { return x * 2 },
-        }
-
-        const result = assignProperties(a, b)
-
-        x = 10
-        expect(result.x).toEqual(10)
-        expect(result.x2).toEqual(20)
-    })
-
-    test('should keep setters alive', () => {
-        let x
-        const a = {
-            set x(v) { x = v },
-        }
-        const c = {
-            set x3(v) { x = v / 3 },
-        }
-
-        const result = assignProperties(a, c)
-
-        result.x = 123
-        expect(x).toEqual(123)
-
-        result.x3 = 300
-        expect(x).toEqual(100)
-    })
-})
+import { flatMap } from './util'
 
 test('flatMap', () => {
     const result = flatMap([0, 1, 2, 3], v => new Array(v).fill(v))

--- a/test/__snapshots__/example-page.test.js.snap
+++ b/test/__snapshots__/example-page.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Freeze-dry an example page as expected 1`] = `
 "<!DOCTYPE html>
 <html><head><meta http-equiv=\\"Content-Security-Policy\\" content=\\"default-src 'none'; img-src data:; media-src data:; style-src data: 'unsafe-inline'; font-src data:; frame-src data:\\">
-        <link rel=\\"stylesheet\\" href=\\"data:text/css;base64,Ym9keSB7CiAgICBjb2xvcjogYmx1ZTsKICAgIGJhY2tncm91bmQ6IHVybCgiZGF0YTppbWFnZS9wbmc7YmFzZTY0LGlWQk9SdzBLR2dvQUFBQU5TVWhFVWdBQUFBRUFBQUFCQ0FZQUFBQWZGY1NKQUFBQURVbEVRVlFJbVdOZ2FHRDREd0FDaEFHQTJGSmRpUUFBQUFCSlJVNUVya0pnZ2c9PSIpOwp9Cg==\\" data-original-href=\\"https://example.com/main/style/style.css\\">
+        <link rel=\\"stylesheet\\" href=\\"data:text/css;base64,QGltcG9ydCAnZGF0YTp0ZXh0L2NzcztiYXNlNjQsYUhSdGJDQjdDaUFnSUNCaVlXTnJaM0p2ZFc1a09pQmpiM1psY2lCMWNtd29aR0YwWVRwcGJXRm5aUzl3Ym1jN1ltRnpaVFkwTEdsV1FrOVNkekJMUjJkdlFVRkJRVTVUVldoRlZXZEJRVUZCUlVGQlFVRkNRMEZaUVVGQlFXWkdZMU5LUVVGQlFVUlZiRVZSVmxGSmJWZE9aMkZIUkRSRWQwRkRhRUZIUVRKR1NtUnBVVUZCUVVGQ1NsSlZOVVZ5YTBwbloyYzlQU2tLZlFvPSc7CkBmb250LWZhY2UgewogICAgZm9udC1mYW1pbHk6ICJNeSBGb250IjsKICAgIHNyYzogdXJsKCJkYXRhOmZvbnQvd29mZjtiYXNlNjQsVG05MElHRnVJR0ZqZEhWaGJDQjNiMlptSUdacGJHVXVMaUJpZFhRc0lIZG9ZWFJsZG1WeUxnbz0iKSBmb3JtYXQoIndvZmYiKTsKfQoKYm9keSB7CiAgICBjb2xvcjogYmx1ZTsKICAgIGJhY2tncm91bmQ6IHVybCgiZGF0YTppbWFnZS9wbmc7YmFzZTY0LGlWQk9SdzBLR2dvQUFBQU5TVWhFVWdBQUFBRUFBQUFCQ0FZQUFBQWZGY1NKQUFBQURVbEVRVlFJbVdOZ2FHRDREd0FDaEFHQTJGSmRpUUFBQUFCSlJVNUVya0pnZ2c9PSIpOwp9Cg==\\" data-original-href=\\"https://example.com/main/style/style.css\\">
         <style>
             p {
                 background: url(\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgaGD4DwAChAGA2FJdiQAAAABJRU5ErkJggg==\\");

--- a/test/example-page.test.js
+++ b/test/example-page.test.js
@@ -56,6 +56,7 @@ function mockFetch(url) {
         'html': 'text/html',
         'css': 'text/css',
         'png': 'image/png',
+        'woff': 'font/woff',
     }
 
     if (url.startsWith(websiteOrigin)) {

--- a/test/example-page/main/style/imported-sheet.css
+++ b/test/example-page/main/style/imported-sheet.css
@@ -1,0 +1,3 @@
+html {
+    background: cover url(/imgs/background.png)
+}

--- a/test/example-page/main/style/myfont.woff
+++ b/test/example-page/main/style/myfont.woff
@@ -1,0 +1,1 @@
+Not an actual woff file.. but, whatever.

--- a/test/example-page/main/style/style.css
+++ b/test/example-page/main/style/style.css
@@ -1,3 +1,9 @@
+@import './imported-sheet.css';
+@font-face {
+    font-family: "My Font";
+    src: url("myfont.woff") format("woff");
+}
+
 body {
     color: blue;
     background: url("../../imgs/background.png");


### PR DESCRIPTION
I am tempted to try use [CSSOM](https://www.w3.org/TR/cssom-1/) instead of parsing things ourselves, but I think that would drop the original comments, layout, etcetera (but have not tried it thoroughly). Largely a question of priorities however, as we may not care about those. In any case, I hope this suffices for the time being.
