### PR TITLE
make resource fetcher configurable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,8 @@ to `window.document`. Possible options are:
   URLs inside stylesheets are still lost.
 - `now` (Date): Overrides the snapshot time (only relevant when `addMetadata` is true). Mainly
   intended for testing purposes.
+- `fetchResource`: custom function for fetching resources; should be API-compatible with the global
+  `fetch()`, but may also return an object `{ blob, url }` instead of a `Response`.
 
 Note that the resulting string can easily be several megabytes when pages contain images, videos,
 fonts, etcetera.

--- a/src/crawl-subresources.js
+++ b/src/crawl-subresources.js
@@ -7,7 +7,8 @@ import { extractLinksFromDom, extractLinksFromCss } from './extract-links'
 /**
  * Recursively fetch the subresources of a DOM resource.
  * @param {Object} resource - the resource object representing the DOM with its subresources.
- * @param {Function} options.fetchResource - function API compatible with fetch (default) for fetching resources.
+ * @param {Function} [options.fetchResource] - custom function for fetching resources; should be
+ * API-compatible with the global fetch(), but may also return { blob, url } instead of a Response.
  * @returns nothing; subresources are stored in the links of the given resource.
  */
 async function crawlSubresourcesOfDom(resource, options) {
@@ -22,6 +23,10 @@ async function crawlSubresourcesOfDom(resource, options) {
     await crawlSubresources(linksToCrawl, options)
 }
 export default crawlSubresourcesOfDom
+
+async function crawlSubresources(links, options) {
+  await whenAllSettled(links.map(link => crawlSubresource(link, options)))
+}
 
 async function crawlSubresource(link, options) {
     const crawlers = {
@@ -38,16 +43,11 @@ async function crawlSubresource(link, options) {
     await crawler(link, options)
 }
 
-function crawlSubresources(links, options) {
-  return whenAllSettled(links.map(link => crawlSubresource(link, options)))
-}
-
 async function crawlLeafSubresource(link, options) {
-    const response = await fetchSubresource(link.absoluteTarget, options)
-    const blob = await response.blob()
+    const fetchedResource = await fetchSubresource(link.absoluteTarget, options)
     link.resource = {
-        url: response.url, // may differ from link.absoluteTarget in case of redirects.
-        blob,
+        url: fetchedResource.url,
+        blob: fetchedResource.blob,
         links: [],
     }
 }
@@ -57,13 +57,14 @@ async function crawlFrame(link, options) {
     if (!link.resource) {
         // Apparently we could not capture the frame's DOM in the initial step. To still do the best
         // we can, we fetch and parse the framed document's html source and work with that.
-        const response = await fetchSubresource(link.absoluteTarget, options)
-        const html = await response.text()
+        const fetchedResource = await fetchSubresource(link.absoluteTarget, options)
+        const html = await blobToText(fetchedResource.blob)
         const parser = new DOMParser()
         const innerDoc = parser.parseFromString(html, 'text/html')
-        const innerDocUrl = response.url // may differ from link.absoluteTarget in case of redirects
+        // Note that the final URL may differ from link.absoluteTarget in case of redirects.
+        const innerDocUrl = fetchedResource.url
 
-        // Create a resource object for this frame, similar to the resource captureDom() returns.
+        // Create a mutable resource for this frame, similar to the resource captureDom() returns.
         const innerDocResource = {
             url: innerDocUrl,
             doc: innerDoc,
@@ -82,9 +83,10 @@ async function crawlFrame(link, options) {
 }
 
 async function crawlStylesheet(link, options) {
-    const response = await fetchSubresource(link.absoluteTarget, options)
-    const stylesheetUrl = response.url // may differ from link.absoluteTarget in case of redirects.
-    const originalStylesheetText = await response.text()
+    const fetchedResource = await fetchSubresource(link.absoluteTarget, options)
+    // Note that the final URL may differ from link.absoluteTarget in case of redirects.
+    const stylesheetUrl = fetchedResource.url
+    const originalStylesheetText = await blobToText(fetchedResource.blob)
 
     let links
     let getCurrentStylesheetText
@@ -111,12 +113,30 @@ async function crawlStylesheet(link, options) {
     await crawlSubresources(stylesheetResource.links, options)
 }
 
-async function fetchSubresource(url, {fetchResource}) {
-    // TODO investigate whether we should supply origin, credentials, perhaps
-    // use content.fetch (in Firefox extensions), etcetera.
-    const response = await fetchResource(url, {
+async function fetchSubresource(url, options) {
+    const fetchFunction = options.fetchResource || self.fetch
+    // TODO investigate whether we should supply origin, credentials, ...
+    const resourceOrResponse = await fetchFunction(url, {
         cache: 'force-cache',
         redirect: 'follow',
     })
-    return response
+    const resource = {
+        // If we got a Response, we wait for the content to arrive.
+        blob: typeof resourceOrResponse.blob === 'function'
+            ? await resourceOrResponse.blob()
+            : resourceOrResponse.blob,
+        // Read the final URL of the resource (after any redirects), or fall back to the known URL.
+        url: resourceOrResponse.url || url,
+    }
+    return resource
+}
+
+async function blobToText(blob) {
+    const text = await new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(reader.result)
+        reader.onerror = () => reject(reader.error)
+        reader.readAsText(blob) // TODO should we know&tell which encoding to use?
+    })
+    return text
 }

--- a/src/crawl-subresources.js
+++ b/src/crawl-subresources.js
@@ -125,8 +125,8 @@ async function fetchSubresource(url, options) {
         blob: typeof resourceOrResponse.blob === 'function'
             ? await resourceOrResponse.blob()
             : resourceOrResponse.blob,
-        // Read the final URL of the resource (after any redirects), or fall back to the known URL.
-        url: resourceOrResponse.url || url,
+        // Read the final URL of the resource (after any redirects).
+        url: resourceOrResponse.url,
     }
     return resource
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ import createSingleFile from './create-single-file'
  * Note this is an unstandardised workaround to keep URLs of subresources available; unfortunately
  * URLs inside stylesheets are still lost.
  * @param {Date} [options.now] - Override the snapshot time (only relevant when addMetadata=true).
- * @param {Function} [options.fetchResource] - function API compatible with fetch (default) for fetching resources.
+ * @param {Function} [options.fetchResource] - Custom function for fetching resources; should be
+ * API-compatible with the global fetch(), but may also return { blob, url } instead of a Response.
  * @returns {string} html - The freeze-dried document as a self-contained, static string of HTML.
  */
 export default async function freezeDry(doc = window.document, {
@@ -26,7 +27,7 @@ export default async function freezeDry(doc = window.document, {
     docUrl,
     addMetadata = true,
     keepOriginalAttributes = true,
-    fetchResource = self.fetch,
+    fetchResource,
     now = new Date(),
 } = {}) {
     // Step 1: Capture the DOM (as well as DOMs inside frames).
@@ -35,7 +36,7 @@ export default async function freezeDry(doc = window.document, {
     // TODO Allow continuing processing elsewhere (background script, worker, nodejs, ...)
 
     // Step 2: Fetch subresources, recursively.
-    await maxWait(timeout)(crawlSubresourcesOfDom(resource, {fetchResource}))
+    await maxWait(timeout)(crawlSubresourcesOfDom(resource, { fetchResource }))
     // TODO Upon timeout, abort the pending fetches on platforms that support this.
 
     // Step 3: "Dry" the resources to make them static and context-free.

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import createSingleFile from './create-single-file'
  * Note this is an unstandardised workaround to keep URLs of subresources available; unfortunately
  * URLs inside stylesheets are still lost.
  * @param {Date} [options.now] - Override the snapshot time (only relevant when addMetadata=true).
+ * @param {Function} [options.fetchResource] - function API compatible with fetch (default) for fetching resources.
  * @returns {string} html - The freeze-dried document as a self-contained, static string of HTML.
  */
 export default async function freezeDry(doc = window.document, {
@@ -25,6 +26,7 @@ export default async function freezeDry(doc = window.document, {
     docUrl,
     addMetadata = true,
     keepOriginalAttributes = true,
+    fetchResource = self.fetch,
     now = new Date(),
 } = {}) {
     // Step 1: Capture the DOM (as well as DOMs inside frames).
@@ -33,7 +35,7 @@ export default async function freezeDry(doc = window.document, {
     // TODO Allow continuing processing elsewhere (background script, worker, nodejs, ...)
 
     // Step 2: Fetch subresources, recursively.
-    await maxWait(timeout)(crawlSubresourcesOfDom(resource))
+    await maxWait(timeout)(crawlSubresourcesOfDom(resource, {fetchResource}))
     // TODO Upon timeout, abort the pending fetches on platforms that support this.
 
     // Step 3: "Dry" the resources to make them static and context-free.


### PR DESCRIPTION
This change introduces `fetchResource` option, which by default is `self.fetch` (to match current behavior). This allows passing custom resource fetching mechanism that can overcome CORS limitations imposed by the host. Specifically it enables:

1. Route resource fetches through own CORS proxy to overcome lack of Access-Control-Headers.
2. Allows one to use alternate resource fetching mechanism e.g. Beakers [`globalFetch`](https://beakerbrowser.com/docs/apis/experimental-globalfetch).